### PR TITLE
Changes to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ env:
     global:
         - REPO_DIR=biopython
         # Commit from your-project that you want to build
-        # biopython-176 (not yet tagged):
-        - BUILD_COMMIT=036fb8d500fffc625f4d26d183c99a0a064e8c3e
+        # biopython-177 (not yet tagged):
+        - BUILD_COMMIT=adac231c9b1470a7f8036876d5d02959554c1bbb
         - PLAT=x86_64
         - UNICODE_WIDTH=32
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,35 +30,6 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-        - TEST_DEPENDS="numpy==1.8.0"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-        - TEST_DEPENDS="numpy==1.8.0"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - TEST_DEPENDS="numpy==1.8.0"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-        - TEST_DEPENDS="numpy==1.8.0"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - TEST_DEPENDS="numpy==1.10.1"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
-        - TEST_DEPENDS="numpy==1.10.1"
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.6
         - TEST_DEPENDS="numpy==1.10.1"
     - os: linux
@@ -84,16 +55,6 @@ matrix:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.17.3"
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - TEST_DEPENDS="numpy==1.8.0"
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - TEST_DEPENDS="numpy==1.10.1"
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,62 +16,56 @@ env:
             "5/U+SFc0p1n07i9Hy091YkpLDXxOZviczNYW/juQqQVqqSjwgWoVhkkfy7vJrc0+NwSf8pVD7Lq8WdUhAygbXAN443/R4wATbWi87oLwXrOLLpwWBEDnRzhPxANMq6ADigXm8rjZJnkEDmB2gs8yTOXDVxgysGl1a4+3nXezeITolcaaTgh5x7XslwmFEwhnZxLxh/TkpyEGEtvi6tEB3mCEJzcFQ0DS3InEXp8qJRkX+QH8zJc9cUO9PPJ3BSHzm8MvdXG+CAcaA9UJwonBRsNqDlrQIdZLEMxTzNMnfVOMbam9zMLaeFc0RjcVALKKhS3UJ5xU6CnwBToz9LWTCvi6hs6Ijooj4gYCLTijKgZAheU0/BlNqc6UcL25b9OSMLr1VvFoWxsxMi2tPAj0TnaR+zI03UutGNgbbf659HpyOgi7b/t460OhNnd2HM4xBYbevYqt3t7cQ/43cacCocaC92Y0ZNTEIsJduVt3Un/FPe8Fbmcm/iXCwx0ZI95c0PmAbkz1PipVtVPGPqYMLQi5WLpBAcYUINxREQtoukh6k55pbaHWBNKfkradRQZMRR7/B0xBkJVZwwsxJjg6dbq9HcQQ/t5nZzlCcagn3m1awjIqx7LiyzYF3AvDWL2itpEseA5wIPFadGHPBlt/69lvG1qJ+LnTjzFXSPY4j1w="
 
 language: python
+python: 3.6
 os: linux
-dist: bionic
+dist: trusty
 services: docker
 
 jobs:
   include:
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - TEST_DEPENDS="numpy==1.10.1"
-      python: 3.6
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-        - TEST_DEPENDS="numpy==1.10.1"
-      python: 3.6
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - TEST_DEPENDS="numpy==1.14.5"
-      python: 3.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - PLAT=i686
-        - TEST_DEPENDS="numpy==1.14.5"
-      python: 3.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.8
-        - TEST_DEPENDS="numpy==1.17.3"
-      python: 3.8
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.8
-        - PLAT=i686
-        - TEST_DEPENDS="numpy==1.17.3"
+      # add osx first into the queue as they have lower parallelism
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - TEST_DEPENDS="numpy==1.12.0"
-      python: 3.6
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
         - TEST_DEPENDS="numpy==1.14.5"
-      python: 3.7
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8
         - TEST_DEPENDS="numpy==1.17.3"
-      python: 3.8
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - TEST_DEPENDS="numpy==1.12.0"
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=i686
+        - TEST_DEPENDS="numpy==1.12.0"
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - TEST_DEPENDS="numpy==1.14.5"
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=i686
+        - TEST_DEPENDS="numpy==1.14.5"
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - TEST_DEPENDS="numpy==1.17.3"
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=i686
+        - TEST_DEPENDS="numpy==1.17.3"
 
 before_install:
     - BUILD_DEPENDS="wheel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,60 +16,63 @@ env:
             "5/U+SFc0p1n07i9Hy091YkpLDXxOZviczNYW/juQqQVqqSjwgWoVhkkfy7vJrc0+NwSf8pVD7Lq8WdUhAygbXAN443/R4wATbWi87oLwXrOLLpwWBEDnRzhPxANMq6ADigXm8rjZJnkEDmB2gs8yTOXDVxgysGl1a4+3nXezeITolcaaTgh5x7XslwmFEwhnZxLxh/TkpyEGEtvi6tEB3mCEJzcFQ0DS3InEXp8qJRkX+QH8zJc9cUO9PPJ3BSHzm8MvdXG+CAcaA9UJwonBRsNqDlrQIdZLEMxTzNMnfVOMbam9zMLaeFc0RjcVALKKhS3UJ5xU6CnwBToz9LWTCvi6hs6Ijooj4gYCLTijKgZAheU0/BlNqc6UcL25b9OSMLr1VvFoWxsxMi2tPAj0TnaR+zI03UutGNgbbf659HpyOgi7b/t460OhNnd2HM4xBYbevYqt3t7cQ/43cacCocaC92Y0ZNTEIsJduVt3Un/FPe8Fbmcm/iXCwx0ZI95c0PmAbkz1PipVtVPGPqYMLQi5WLpBAcYUINxREQtoukh6k55pbaHWBNKfkradRQZMRR7/B0xBkJVZwwsxJjg6dbq9HcQQ/t5nZzlCcagn3m1awjIqx7LiyzYF3AvDWL2itpEseA5wIPFadGHPBlt/69lvG1qJ+LnTjzFXSPY4j1w="
 
 language: python
-# The travis Python version is unrelated to the version we build and test
-# with.  This is set with the MB_PYTHON_VERSION variable.
-python: 3.5
-sudo: required
-dist: trusty
+os: linux
+dist: bionic
 services: docker
 
-matrix:
-  exclude:
-    # Exclude the default (TravisCI provided) Python 3.5 build
-    - python: 3.5
+jobs:
   include:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - TEST_DEPENDS="numpy==1.10.1"
+      python: 3.6
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.10.1"
+      python: 3.6
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - TEST_DEPENDS="numpy==1.14.5"
+      python: 3.7
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.14.5"
+      python: 3.7
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
         - TEST_DEPENDS="numpy==1.17.3"
+      python: 3.8
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.17.3"
+      python: 3.8
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - TEST_DEPENDS="numpy==1.12.0"
+      python: 3.6
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
         - TEST_DEPENDS="numpy==1.14.5"
+      python: 3.7
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.8
         - TEST_DEPENDS="numpy==1.17.3"
+      python: 3.8
 
 before_install:
     - BUILD_DEPENDS="wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ environment:
   global:
     REPO_DIR: biopython
     PACKAGE_NAME: biopython
-    # biopython-176 (not yet tagged):
-    BUILD_COMMIT: 036fb8d500fffc625f4d26d183c99a0a064e8c3e
+    # biopython-177 (not yet tagged):
+    BUILD_COMMIT: adac231c9b1470a7f8036876d5d02959554c1bbb
     WHEELHOUSE_UPLOADER_USERNAME: travis-worker
     WHEELHOUSE_UPLOADER_SECRET:
         secure:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,14 +22,6 @@ environment:
       TEST_DEPENDS: "numpy==1.12.0"
     - PYTHON: "C:\\Python36-x64"
       TEST_DEPENDS: "numpy==1.12.0"
-    - PYTHON: "C:\\Python35"
-      TEST_DEPENDS: "numpy==1.10.4"
-    - PYTHON: "C:\\Python35-x64"
-      TEST_DEPENDS: "numpy==1.10.4"
-    - PYTHON: "C:\\Python27"
-      TEST_DEPENDS: "numpy==1.8.0"
-    - PYTHON: "C:\\Python27-x64"
-      TEST_DEPENDS: "numpy==1.8.0"
 
 matrix:
     fast_finish: false  # for testing
@@ -86,10 +78,6 @@ test_script:
     - mv ..\\%REPO_DIR%\\Tests Tests
     - mv ..\\%REPO_DIR%\\Doc Doc
     - cd Tests
-    # Disable doctest which breaks under 64-bit Python 2.7
-    - "sed -i.tmp 's:\"Bio.Affy.CelFile\",:# Skip Bio.Affy.CelFile:g' run_tests.py"
-    # Disable int vs long tutorial doctest which breaks under 32-bit Python 3.5
-    - rm ..\\Doc\\Tutorial\\chapter_phenotype.tex
     # Disable alignment tutorial doctest failure specfic to Windows
     - rm ..\\Doc\\Tutorial\\chapter_align.tex
     # Disable two more platform specific failures

--- a/config.sh
+++ b/config.sh
@@ -38,7 +38,6 @@ function run_tests {
     python -c "import Bio; print('Biopython version: ' + Bio.__version__)"
     python -c "import Bio; print(Bio.__file__)"
     python -c "import os, Bio; print(os.listdir(os.path.split(Bio.__file__)[0]))"
-    python -c "import os, Bio; print(os.listdir(os.path.split(Bio.__file__)[0] + '/KDTree'))"
     python -c "import os, Bio; print(os.listdir(os.path.split(Bio.__file__)[0] + '/Align'))"
     # This will confirm some of our C code compiled fine:
     python -c "from Bio.Nexus import cnexus; from Bio import cpairwise2"


### PR DESCRIPTION
This PR hopefully addresses build errors with the removal of old Python versions. The changes here have passed the validator at https://config.travis-ci.com/explore with deprecated tags removed and the distribution updated to bionic (18.04).