### PR TITLE
RackSpace -> AnaConda for staging wheels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
     PACKAGE_NAME: biopython
     # biopython-177 (not yet tagged):
     BUILD_COMMIT: adac231c9b1470a7f8036876d5d02959554c1bbb
+    BIOPYTHON_STAGING_UPLOAD_TOKEN:
+      secure: sulPawBUvpS2XWg79MIKiFINMnlPv6BbBcC4rXhcXNEIJIOufv0Ve+VYTbUPHfgv
 
   matrix:
     - PYTHON: "C:\\Python38"
@@ -86,4 +88,15 @@ artifacts:
     - path: "%REPO_DIR%\\dist\\*"
 
 on_success:
-    - echo "TODO - upload wheels to staging area..."
+    # Upload wheels to anaconda for staging before PyPI, using shared
+    # infrastructure at https://anaconda.org/multibuild-wheels-staging
+    # The secret token is defined in the AppVeyor configuration
+    # from https://anaconda.org/scipy-wheels-nightly/settings/access
+    - $env:ANACONDA_ORG="multibuild-wheels-staging"
+    - $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN
+    - python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
+    - if (Test-Path env:ANACONDA_TOKEN) {
+        anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl
+      } else {
+        echo "Not uploading since token not set (expected if this is a pull request)"
+      }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,8 +94,8 @@ on_success:
     # from https://anaconda.org/scipy-wheels-nightly/settings/access
     - python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
     - ps: >-
-        $env:ANACONDA_ORG="multibuild-wheels-staging"
-        $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN
+        $env:ANACONDA_ORG="multibuild-wheels-staging";
+        $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN;
         if (Test-Path env:ANACONDA_TOKEN) {
           anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl
         } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,11 +93,5 @@ on_success:
     # The secret token is defined in the AppVeyor configuration
     # from https://anaconda.org/scipy-wheels-nightly/settings/access
     - python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
-    - ps: >-
-        $env:ANACONDA_ORG="multibuild-wheels-staging";
-        $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN;
-        if (Test-Path env:ANACONDA_TOKEN) {
-          anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl --no-progress
-        } else {
-          echo "Not uploading since token not set (expected if this is a pull request)"
-        }
+    - cmd: set ANACONDA_ORG="multibuild-wheels-staging"
+    - IF NOT "%BIOPYTON_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %BIOPYTHON_STAGING_UPLOAD_TOKEN% upload --force --no-progress -u %ANACONDA_ORG% "dist\*.whl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,5 +93,4 @@ on_success:
     # The secret token is defined in the AppVeyor configuration
     # from https://anaconda.org/scipy-wheels-nightly/settings/access
     - python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
-    - cmd: set ANACONDA_ORG="multibuild-wheels-staging"
-    - IF NOT "%BIOPYTON_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %BIOPYTHON_STAGING_UPLOAD_TOKEN% upload --force --no-progress -u %ANACONDA_ORG% "dist\*.whl"
+    - IF NOT "%BIOPYTHON_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %BIOPYTHON_STAGING_UPLOAD_TOKEN% upload --force --no-progress -u "multibuild-wheels-staging" "dist\*.whl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -97,7 +97,7 @@ on_success:
         $env:ANACONDA_ORG="multibuild-wheels-staging";
         $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN;
         if (Test-Path env:ANACONDA_TOKEN) {
-          anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl
+          anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl --no-progress
         } else {
           echo "Not uploading since token not set (expected if this is a pull request)"
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,11 +92,12 @@ on_success:
     # infrastructure at https://anaconda.org/multibuild-wheels-staging
     # The secret token is defined in the AppVeyor configuration
     # from https://anaconda.org/scipy-wheels-nightly/settings/access
-    - $env:ANACONDA_ORG="multibuild-wheels-staging"
-    - $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN
     - python -m pip install git+https://github.com/Anaconda-Server/anaconda-client.git
-    - if (Test-Path env:ANACONDA_TOKEN) {
-        anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl
-      } else {
-        echo "Not uploading since token not set (expected if this is a pull request)"
-      }
+    - ps: >-
+        $env:ANACONDA_ORG="multibuild-wheels-staging"
+        $env:ANACONDA_TOKEN = $env:BIOPYTHON_STAGING_UPLOAD_TOKEN
+        if (Test-Path env:ANACONDA_TOKEN) {
+          anaconda -t $env:ANACONDA_TOKEN upload -u $env:ANACONDA_ORG --force $env:REPO_DIR/dist/*.whl
+        } else {
+          echo "Not uploading since token not set (expected if this is a pull request)"
+        }


### PR DESCRIPTION
Matti Picus has given me access to https://anaconda.org/multibuild-wheels-staging/settings/access (under anaconda account peterjc), and as instructed I defined ``$BIOPYTHON_STAGING_UPLOAD_TOKEN`` with permissions "Allow all operations on PyPI repositories".

This is now added to the TravisCI configuration as a secret environment variable; AppVeyor pending.