### PR TITLE
Add aarch64 wheel build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,14 @@ jobs:
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.12.0"
     - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - TEST_DEPENDS="numpy==1.19.0"
+    - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
         - TEST_DEPENDS="numpy==1.14.5"
@@ -54,6 +62,14 @@ jobs:
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.14.5"
     - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - TEST_DEPENDS="numpy==1.19.3"
+    - os: linux
       env:
         - MB_PYTHON_VERSION=3.8
         - TEST_DEPENDS="numpy==1.17.3"
@@ -62,6 +78,14 @@ jobs:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
         - TEST_DEPENDS="numpy==1.17.3"
+    - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
+        - TEST_DEPENDS="numpy==1.19.5"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.9
@@ -70,6 +94,14 @@ jobs:
       env:
         - MB_PYTHON_VERSION=3.9
         - PLAT=i686
+        - TEST_DEPENDS="numpy==1.20"
+    - os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.9
+        - PLAT=aarch64
+        - MB_ML_VER=2014
+        - DOCKER_TEST_IMAGE=multibuild/xenial_{PLAT}
         - TEST_DEPENDS="numpy==1.20"
 
 before_install:

--- a/config.sh
+++ b/config.sh
@@ -15,6 +15,9 @@ function run_tests {
     else
         echo "Forcing en_US.UTF-8 as workaround for encoding issues in Biopython 1.70 tests"
         # There is likely a more consise method to do this, but this works:
+        if [ "$(uname -m)" == "aarch64" ]; then
+            apt-get install -y sudo locales language-pack-en-base
+        fi
         sudo echo "LANG=en_US.UTF-8" > /etc/default/locale
         sudo locale-gen en_US.UTF-8
         sudo dpkg-reconfigure locales


### PR DESCRIPTION
Add aarch64 wheel build support.
Related to https://github.com/biopython/biopython-wheels/issues/10 @peterjc Could you please review this PR?