### PR TITLE
Update to cibuildwheel v2.13.1

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,10 +34,10 @@ jobs:
           cd ..
 
       # Could not work out how to give package path with
-      # uses: pypa/cibuildwheel@v2.11.2
+      # uses: pypa/cibuildwheel@v2.14.0
       - name: Build wheels
         run: |
-          pipx run cibuildwheel==2.11.2 --output-dir wheelhouse biopython
+          pipx run cibuildwheel==2.14.0 --output-dir wheelhouse biopython
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,10 +34,10 @@ jobs:
           cd ..
 
       # Could not work out how to give package path with
-      # uses: pypa/cibuildwheel@v2.14.0
+      # uses: pypa/cibuildwheel@v2.13.1
       - name: Build wheels
         run: |
-          pipx run cibuildwheel==2.14.0 --output-dir wheelhouse biopython
+          pipx run cibuildwheel==2.13.1 --output-dir wheelhouse biopython
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Still targetting Biopython 1.81 (which includes Python 3.7 support).

This is a step towards trying to build Apple-silicon ARM wheels, https://github.com/biopython/biopython/issues/4315