### PR TITLE
Update checkout and upload-artifact

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -20,7 +20,7 @@ jobs:
       CIBW_TEST_COMMAND: "python {package}/Tests/test_Cluster.py"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Optional
           submodules: true  # Optional, use if you have submodules
@@ -39,6 +39,6 @@ jobs:
         run: |
           pipx run cibuildwheel==2.13.1 --output-dir wheelhouse biopython
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
This should solve the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/