### PR TITLE
Create wheels for ARM on linux

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -17,8 +17,7 @@ jobs:
       CIBW_BEFORE_BUILD: "pip install --only-binary :all: -r requirements.txt"
       # There are/were no numpy wheels for these:
       CIBW_SKIP: pp37-* pp38-* pp39-* pp310-* cp39-manylinux_i686 cp310-manylinux_i686 cp311-manylinux_i686 cp312-manylinux_i686 *-musllinux_*
-      # configure cibuildwheel to build native archs ('auto'), and some
-      # emulated ones
+      # configure cibuildwheel to build native arch & aarch64 too
       CIBW_ARCHS_LINUX: auto aarch64
       # Quick test with C code using NumPy C API:
       CIBW_TEST_COMMAND: "python {package}/Tests/test_Cluster.py"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -17,6 +17,9 @@ jobs:
       CIBW_BEFORE_BUILD: "pip install --only-binary :all: -r requirements.txt"
       # There are/were no numpy wheels for these:
       CIBW_SKIP: pp37-* pp38-* pp39-* pp310-* cp39-manylinux_i686 cp310-manylinux_i686 cp311-manylinux_i686 cp312-manylinux_i686 *-musllinux_*
+      # configure cibuildwheel to build native archs ('auto'), and some
+      # emulated ones
+      CIBW_ARCHS_LINUX: auto aarch64
       # Quick test with C code using NumPy C API:
       CIBW_TEST_COMMAND: "python {package}/Tests/test_Cluster.py"
 
@@ -25,6 +28,12 @@ jobs:
         with:
           fetch-depth: 0  # Optional
           submodules: true  # Optional, use if you have submodules
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Checkout tag/commit
         run: |


### PR DESCRIPTION
I am trying to use `biopython==1.84` within a Ubuntu docker image on an M2 Macbook Pro but there's no wheel built for this environment and it's causing installation issues for us.

I've changed the build script so that `cibuildwheel` also outputs wheels for aarch64 from the ubuntu-20.04 runner.

You can see the [CI run](https://github.com/Bactobio/biopython-wheels/actions/runs/9714203028/job/26812730076) for this has successfully produced the wheels, and [download the artifacts](https://github.com/Bactobio/biopython-wheels/actions/runs/9714203028/artifacts/1648975342).



